### PR TITLE
CAPS-108: monaco-editor 부분 수정

### DIFF
--- a/components/createDiscussion/CreateDiscussionComponent.tsx
+++ b/components/createDiscussion/CreateDiscussionComponent.tsx
@@ -84,10 +84,20 @@ const CreateDiscussionComponent: React.FunctionComponent<Props> = () => {
 					onChange={(e) => setTitle(e.target.value)}
 				/>
 				<div className="m-2">
-					<div className="btn btn-ghost w-[12rem]" onClick={selectDirect}>
+					<div
+						className={`btn w-[12rem] ${
+							discussionType == 'DIRECT' ? 'btn-accent' : 'btn-ghost'
+						}`}
+						onClick={selectDirect}
+					>
 						직접 코드 작성하기
 					</div>
-					<div className="btn btn-ghost w-[15rem]" onClick={selectPRorCommit}>
+					<div
+						className={`btn w-[15rem] ml-2 ${
+							discussionType != 'DIRECT' ? 'btn-accent' : 'btn-ghost'
+						}`}
+						onClick={selectPRorCommit}
+					>
 						GitHub에서 코드 가져오기
 					</div>
 				</div>

--- a/components/createDiscussion/DirectCodeCompoent.tsx
+++ b/components/createDiscussion/DirectCodeCompoent.tsx
@@ -11,17 +11,42 @@ const DirectCodeComponent: React.FunctionComponent<Props> = ({
 	codes,
 	setCodes
 }) => {
-	const [fileNum, setFileNum] = useState<number>(1)
+	const languageGroup = [
+		'JavaScript',
+		'TypeScript',
+		'Java',
+		'Python',
+		'C',
+		'C#',
+		'C++',
+		'HTML',
+		'XML',
+		'PHP',
+		'JSON',
+		'Markdown',
+		'Powershell',
+		'Ruby',
+		'CSS',
+		'SCSS',
+		'SASS',
+		'R'
+	]
+	const [language, setLanguage] = useState<string[]>([])
 	const handleAddFile = () => {
-		setCodes([
-			...codes,
-			{ filename: 'code_' + fileNum, content: '// write codes' }
-		])
-		setFileNum(fileNum + 1)
+		setCodes([...codes, { filename: '', content: '// write codes' }])
 	}
 	const handleDeleteFile = (index: number) => {
 		const newCodes = [...codes]
 		newCodes.splice(index, 1)
+		setCodes(newCodes)
+		const newLanguage = [...language]
+		newLanguage.splice(index, 1)
+		setLanguage(newLanguage)
+	}
+	const handleChangeName = (value: string | undefined, idx: number) => {
+		const newCodes = [...codes]
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		newCodes[idx].filename = value!
 		setCodes(newCodes)
 	}
 	const handleChangeCode = (value: string | undefined, idx: number) => {
@@ -29,6 +54,12 @@ const DirectCodeComponent: React.FunctionComponent<Props> = ({
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		newCodes[idx].content = value!
 		setCodes(newCodes)
+	}
+	const handleLanguage = (value: string | undefined, idx: number) => {
+		const newLanguage = [...language]
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		newLanguage[idx] = value!.toLowerCase()
+		setLanguage(newLanguage)
 	}
 	return (
 		<div className="create_discussion_form">
@@ -39,19 +70,43 @@ const DirectCodeComponent: React.FunctionComponent<Props> = ({
 			</div>
 			{codes.map((code, idx) => {
 				return (
-					<div key={idx} className="flex flex-row">
-						<div className="border-solid border-2 w-full">
-							<MonacoEditor
-								code={code}
-								handleChangeCode={handleChangeCode}
-								idx={idx}
+					<div key={idx} className="flex flex-col">
+						<div className="flex flex-row items-center">
+							<input
+								type="text"
+								placeholder="File명을 입력하세요"
+								className="input input-bordered w-full max-w-[10rem] mt-2 mb-2"
+								value={code.filename}
+								onChange={(e) => handleChangeName(e.target.value, idx)}
 							/>
+							<select
+								className="select select-bordered ml-2"
+								onChange={(e) => handleLanguage(e.target.value, idx)}
+							>
+								{languageGroup.map((lang) => {
+									return (
+										<option key={lang} value={lang}>
+											{lang}
+										</option>
+									)
+								})}
+							</select>
+							<div
+								className="btn btn-error ml-2"
+								onClick={() => handleDeleteFile(idx)}
+							>
+								X
+							</div>
 						</div>
-						<div
-							className="btn btn-error"
-							onClick={() => handleDeleteFile(idx)}
-						>
-							X
+						<div>
+							<div className="border-solid border-2 min-w-[20rem] w-[40rem]">
+								<MonacoEditor
+									code={code}
+									handleChangeCode={handleChangeCode}
+									idx={idx}
+									language={language[idx]}
+								/>
+							</div>
 						</div>
 					</div>
 				)

--- a/components/createDiscussion/MonacoEditor.tsx
+++ b/components/createDiscussion/MonacoEditor.tsx
@@ -10,17 +10,20 @@ type Props = {
 	code: DirectCode
 	handleChangeCode: (value: string, idx: number) => void
 	idx: number
+	language: string
 }
 
 export const MonacoEditor: React.FunctionComponent<Props> = ({
 	code,
 	handleChangeCode,
-	idx
+	idx,
+	language
 }) => {
 	return (
 		<Editor
 			height="15rem"
 			defaultLanguage="javascript"
+			language={language}
 			value={code.content}
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			onChange={(value) => handleChangeCode(value!, idx)}

--- a/components/createDiscussion/PRorCommit.tsx
+++ b/components/createDiscussion/PRorCommit.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
 import { useQuery, useQueryClient } from 'react-query'
 import { getCommits, getMyRepos, getPullRequests } from '../../api/Github'
-import CreateDiscussionForm from '../CreateDiscussionForm'
 
 type Props = {
 	discussionType: 'DIRECT' | 'COMMIT' | 'PR'
@@ -31,7 +30,7 @@ const PRorCommit: React.FunctionComponent<Props> = ({
 	return (
 		<div className="flex flex-col">
 			<select
-				className="select select-primary w-full max-w-xs"
+				className="select select-primary w-full max-w-xs mb-2"
 				onChange={(e) => setSelectedRepo(parseInt(e.target.value))}
 			>
 				<option disabled selected>

--- a/components/createDiscussion/TagButton.tsx
+++ b/components/createDiscussion/TagButton.tsx
@@ -23,18 +23,12 @@ const SelectTagComponent: React.FunctionComponent<Props> = ({
 		setSelect(!select)
 	}
 	return (
-		<>
-			{select === false && (
-				<div className="btn btn-outline btn-primary m-1" onClick={clickTag}>
-					{tagName}
-				</div>
-			)}
-			{select === true && (
-				<div className="btn btn-primary m-1 box-border" onClick={clickTag}>
-					{tagName}
-				</div>
-			)}
-		</>
+		<div
+			className={`btn btn-primary m-1 ${select ? '' : 'btn-outline'}`}
+			onClick={clickTag}
+		>
+			{tagName}
+		</div>
 	)
 }
 


### PR DESCRIPTION
## 작업 내용
 - `filename` input 추가
 - code `language` select box 추가
 - 일부 코드 리팩토링

## 논의사항
 - 추후 discussion 조회 페이지에서도 언어 구분이 있어야하니, `DirectCode` type에 `language`가 추가되면 좋을 것 같습니다.