### PR TITLE
Caps 86 FrontEnd 로그인

### DIFF
--- a/api/User.ts
+++ b/api/User.ts
@@ -32,7 +32,7 @@ export function isLoggedIn() {
 	if(refreshToken != null)
 		refreshTokenDecoded = jwt_decode(refreshToken) as any;
 
-	if(refreshTokenDecoded == null){
+	if(refreshTokenDecoded == null || accessToken == null){
 		return false;
 	}
 	return true

--- a/api/User.ts
+++ b/api/User.ts
@@ -21,7 +21,7 @@ export function getCook(cookiename:String)
   	return decodeURIComponent(!!cookiestring ? cookiestring.toString().replace(/^[^=]+./,"") : "");
 }
 
-export function isLoggedIn() {
+export function isLogined() {
 	var accessToken = getCook('accessToken');
 	var refreshToken = getCook('refreshToken');
 

--- a/api/User.ts
+++ b/api/User.ts
@@ -1,6 +1,5 @@
 import { CommonResponse } from './common'
-import jwt_decode from "jwt-decode";
-
+import jwt_decode from 'jwt-decode'
 
 export type userState = {
 	id: number
@@ -11,36 +10,32 @@ export type userState = {
 	point: number
 } & CommonResponse
 
-
-export function getCook(cookiename:String)
-{
-	if(typeof window !== 'object') return;
-	var cookiestring=RegExp(cookiename+"=[^;]+").exec(document.cookie);
-	if(cookiestring == null)
-		return null;
-  	return decodeURIComponent(!!cookiestring ? cookiestring.toString().replace(/^[^=]+./,"") : "");
+export function getCook(cookiename: string) {
+	if (typeof window !== 'object') return
+	const cookiestring = RegExp(cookiename + '=[^;]+').exec(document.cookie)
+	if (cookiestring == null) return null
+	return decodeURIComponent(
+		cookiestring ? cookiestring.toString().replace(/^[^=]+./, '') : ''
+	)
 }
 
 export function isLogined() {
-	var accessToken = getCook('accessToken');
-	var refreshToken = getCook('refreshToken');
+	const accessToken = getCook('accessToken')
+	const refreshToken = getCook('refreshToken')
 
-	var accessTokenDecoded = null;
-	var refreshTokenDecoded = null;
-	if(accessToken != null)
-		accessTokenDecoded = jwt_decode(accessToken) as any;
-	if(refreshToken != null)
-		refreshTokenDecoded = jwt_decode(refreshToken) as any;
+	let accessTokenDecoded = null
+	let refreshTokenDecoded = null
+	if (accessToken != null) accessTokenDecoded = jwt_decode(accessToken) as any
+	if (refreshToken != null)
+		refreshTokenDecoded = jwt_decode(refreshToken) as any
 
-	if(refreshTokenDecoded == null || accessToken == null){
-		return false;
+	if (refreshTokenDecoded == null || accessToken == null) {
+		return false
 	}
 	return true
 }
 
-
-
 export function signOut() {
-	document.cookie = "accessToken" + '=; expires=Thu, 01 Jan 1999 00:00:10 GMT;';
-	document.cookie = "refreshToken" + '=; expires=Thu, 01 Jan 1999 00:00:10 GMT;';
+	document.cookie = 'accessToken' + '=; expires=Thu, 01 Jan 1999 00:00:10 GMT;'
+	document.cookie = 'refreshToken' + '=; expires=Thu, 01 Jan 1999 00:00:10 GMT;'
 }

--- a/api/User.ts
+++ b/api/User.ts
@@ -1,8 +1,6 @@
 import { CommonResponse } from './common'
+import jwt_decode from "jwt-decode";
 
-export const user = {
-	isLoggedIn: false
-}
 
 export type userState = {
 	id: number
@@ -13,15 +11,36 @@ export type userState = {
 	point: number
 } & CommonResponse
 
-export function isLoggedIn() {
-	if (user.isLoggedIn) return true
-	else return false
+
+export function getCook(cookiename:String)
+{
+	if(typeof window !== 'object') return;
+	var cookiestring=RegExp(cookiename+"=[^;]+").exec(document.cookie);
+	if(cookiestring == null)
+		return null;
+  	return decodeURIComponent(!!cookiestring ? cookiestring.toString().replace(/^[^=]+./,"") : "");
 }
 
-export function signIn() {
-	user.isLoggedIn = true
+export function isLoggedIn() {
+	var accessToken = getCook('accessToken');
+	var refreshToken = getCook('refreshToken');
+
+	var accessTokenDecoded = null;
+	var refreshTokenDecoded = null;
+	if(accessToken != null)
+		accessTokenDecoded = jwt_decode(accessToken) as any;
+	if(refreshToken != null)
+		refreshTokenDecoded = jwt_decode(refreshToken) as any;
+
+	if(refreshTokenDecoded == null){
+		return false;
+	}
+	return true
 }
+
+
 
 export function signOut() {
-	user.isLoggedIn = false
+	document.cookie = "accessToken" + '=; expires=Thu, 01 Jan 1999 00:00:10 GMT;';
+	document.cookie = "refreshToken" + '=; expires=Thu, 01 Jan 1999 00:00:10 GMT;';
 }

--- a/api/User.ts
+++ b/api/User.ts
@@ -19,7 +19,7 @@ export function getCook(cookiename: string) {
 	)
 }
 
-export function isLogined() {
+export function isLogin() {
 	const accessToken = getCook('accessToken')
 	const refreshToken = getCook('refreshToken')
 

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,11 +1,10 @@
-import React, { useEffect,useState, FunctionComponent } from 'react'
+import React, { useEffect, useState, FunctionComponent } from 'react'
 import Link from 'next/link'
-import { isLogined,signOut } from '../../api/User'
+import { isLogined, signOut } from '../../api/User'
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface HeaderProps {}
 
 const Header: FunctionComponent<HeaderProps> = () => {
-	
 	return (
 		<div className="navbar bg-base-100 border-b-2">
 			<div className="flex-1">
@@ -30,10 +29,11 @@ const Header: FunctionComponent<HeaderProps> = () => {
 						</ul>
 					</div>
 				) : (
-					<Link href='http://localhost:8080/oauth2/authorization/github' passHref>
-						<button className="btn btn-primary">
-							sign in
-						</button>
+					<Link
+						href="http://localhost:8080/oauth2/authorization/github"
+						passHref
+					>
+						<button className="btn btn-primary">sign in</button>
 					</Link>
 				)}
 			</div>

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,10 +1,11 @@
-import React, { useState, FunctionComponent } from 'react'
+import React, { useEffect,useState, FunctionComponent } from 'react'
 import Link from 'next/link'
-import { user, isLoggedIn, signIn, signOut } from '../../api/User'
+import { isLoggedIn,signOut } from '../../api/User'
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface HeaderProps {}
 
 const Header: FunctionComponent<HeaderProps> = () => {
+	
 	return (
 		<div className="navbar bg-base-100 border-b-2">
 			<div className="flex-1">
@@ -23,14 +24,14 @@ const Header: FunctionComponent<HeaderProps> = () => {
 						<ul className="menu dropdown-content p-2 shadow bg-base-100 rounded-box w-36 mt-4">
 							<li>
 								<Link href="/">
-									<a onClick={signOut}>Sign Out</a>
+									<button onClick={signOut}>Sign Out</button>
 								</Link>
 							</li>
 						</ul>
 					</div>
 				) : (
-					<Link href="/" passHref>
-						<button onClick={signIn} className="btn btn-primary">
+					<Link href='http://localhost:8080/oauth2/authorization/github' passHref>
+						<button className="btn btn-primary">
 							sign in
 						</button>
 					</Link>

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect,useState, FunctionComponent } from 'react'
 import Link from 'next/link'
-import { isLoggedIn,signOut } from '../../api/User'
+import { isLogined,signOut } from '../../api/User'
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface HeaderProps {}
 
@@ -14,7 +14,7 @@ const Header: FunctionComponent<HeaderProps> = () => {
 				</Link>
 			</div>
 			<div className="navbar-end">
-				{isLoggedIn() ? (
+				{isLogined() ? (
 					<div className="dropdown dropdown-end">
 						<button className="btn btn-ghost btn-circle">
 							<div className="indicator">

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, FunctionComponent } from 'react'
 import Link from 'next/link'
-import { isLogined, signOut } from '../../api/User'
+import { isLogin, signOut } from '../../api/User'
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface HeaderProps {}
 
@@ -13,7 +13,7 @@ const Header: FunctionComponent<HeaderProps> = () => {
 				</Link>
 			</div>
 			<div className="navbar-end">
-				{isLogined() ? (
+				{isLogin() ? (
 					<div className="dropdown dropdown-end">
 						<button className="btn btn-ghost btn-circle">
 							<div className="indicator">
@@ -22,17 +22,14 @@ const Header: FunctionComponent<HeaderProps> = () => {
 						</button>
 						<ul className="menu dropdown-content p-2 shadow bg-base-100 rounded-box w-36 mt-4">
 							<li>
-								<Link href="/">
+								<Link passHref href="/">
 									<button onClick={signOut}>Sign Out</button>
 								</Link>
 							</li>
 						</ul>
 					</div>
 				) : (
-					<Link
-						href="http://localhost:8080/oauth2/authorization/github"
-						passHref
-					>
+					<Link href="/api/oauth2/authorization/github" passHref>
 						<button className="btn btn-primary">sign in</button>
 					</Link>
 				)}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@uiw/react-md-editor": "3.6.0",
         "autoprefixer": "^10.4.4",
         "daisyui": "^2.13.6",
+        "jwt-decode": "^3.1.2",
         "monaco-editor": "^0.33.0",
         "next": "^12.1.1",
         "next-remove-imports": "^1.0.6",
@@ -23,6 +24,7 @@
         "react-daisyui": "^1.7.3",
         "react-dom": "17.0.2",
         "react-query": "^3.34.19",
+        "recoil": "^0.7.2",
         "tailwindcss": "^3.0.23"
       },
       "devDependencies": {
@@ -4117,6 +4119,11 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
       "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
     },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha1-4hwlKWjH4zsg9qGwlM2FeHomVgE="
+    },
     "node_modules/har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -5028,6 +5035,11 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -7424,6 +7436,25 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recoil": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.2.tgz",
+      "integrity": "sha512-OT4pI7FOUHcIoRtjsL5Lqq+lFFzQfir4MIbUkqyJ3nqv3WfBP1pHepyurqTsK5gw+T+I2R8+uOD28yH+Lg5o4g==",
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/redent": {
@@ -12163,6 +12194,11 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
       "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
     },
+    "hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha1-4hwlKWjH4zsg9qGwlM2FeHomVgE="
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -12817,6 +12853,11 @@
         "array-includes": "^3.1.3",
         "object.assign": "^4.1.2"
       }
+    },
+    "jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "kind-of": {
       "version": "6.0.3",
@@ -14439,6 +14480,14 @@
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "recoil": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.2.tgz",
+      "integrity": "sha512-OT4pI7FOUHcIoRtjsL5Lqq+lFFzQfir4MIbUkqyJ3nqv3WfBP1pHepyurqTsK5gw+T+I2R8+uOD28yH+Lg5o4g==",
+      "requires": {
+        "hamt_plus": "1.0.2"
       }
     },
     "redent": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "react-daisyui": "^1.7.3",
         "react-dom": "17.0.2",
         "react-query": "^3.34.19",
-        "recoil": "^0.7.2",
         "tailwindcss": "^3.0.23"
       },
       "devDependencies": {
@@ -4119,11 +4118,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
       "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
     },
-    "node_modules/hamt_plus": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
-      "integrity": "sha1-4hwlKWjH4zsg9qGwlM2FeHomVgE="
-    },
     "node_modules/har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -7436,25 +7430,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/recoil": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.2.tgz",
-      "integrity": "sha512-OT4pI7FOUHcIoRtjsL5Lqq+lFFzQfir4MIbUkqyJ3nqv3WfBP1pHepyurqTsK5gw+T+I2R8+uOD28yH+Lg5o4g==",
-      "dependencies": {
-        "hamt_plus": "1.0.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.13.1"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
       }
     },
     "node_modules/redent": {
@@ -12194,11 +12169,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
       "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
     },
-    "hamt_plus": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
-      "integrity": "sha1-4hwlKWjH4zsg9qGwlM2FeHomVgE="
-    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -14480,14 +14450,6 @@
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "requires": {
         "picomatch": "^2.2.1"
-      }
-    },
-    "recoil": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.2.tgz",
-      "integrity": "sha512-OT4pI7FOUHcIoRtjsL5Lqq+lFFzQfir4MIbUkqyJ3nqv3WfBP1pHepyurqTsK5gw+T+I2R8+uOD28yH+Lg5o4g==",
-      "requires": {
-        "hamt_plus": "1.0.2"
       }
     },
     "redent": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@uiw/react-md-editor": "3.6.0",
     "autoprefixer": "^10.4.4",
     "daisyui": "^2.13.6",
+    "jwt-decode": "^3.1.2",
     "monaco-editor": "^0.33.0",
     "next": "^12.1.1",
     "next-remove-imports": "^1.0.6",
@@ -24,6 +25,7 @@
     "react-daisyui": "^1.7.3",
     "react-dom": "17.0.2",
     "react-query": "^3.34.19",
+    "recoil": "^0.7.2",
     "tailwindcss": "^3.0.23"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "react-daisyui": "^1.7.3",
     "react-dom": "17.0.2",
     "react-query": "^3.34.19",
-    "recoil": "^0.7.2",
     "tailwindcss": "^3.0.23"
   },
   "devDependencies": {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,13 +2,6 @@ import '../styles/globals.css'
 import type { AppProps } from 'next/app'
 import { useState } from 'react'
 import { Hydrate, QueryClient, QueryClientProvider } from 'react-query'
-import {
-	RecoilRoot,
-	atom,
-	selector,
-	useRecoilState,
-	useRecoilValue,
-  } from 'recoil';
 
 function MyApp({ Component, pageProps }: AppProps) {
 	const [queryClient, setQueryClient] = useState<QueryClient>(
@@ -21,7 +14,6 @@ function MyApp({ Component, pageProps }: AppProps) {
 				<Component {...pageProps}></Component>
 			</Hydrate>
 		</QueryClientProvider>
-		
 	)
 }
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,6 +2,13 @@ import '../styles/globals.css'
 import type { AppProps } from 'next/app'
 import { useState } from 'react'
 import { Hydrate, QueryClient, QueryClientProvider } from 'react-query'
+import {
+	RecoilRoot,
+	atom,
+	selector,
+	useRecoilState,
+	useRecoilValue,
+  } from 'recoil';
 
 function MyApp({ Component, pageProps }: AppProps) {
 	const [queryClient, setQueryClient] = useState<QueryClient>(
@@ -14,6 +21,7 @@ function MyApp({ Component, pageProps }: AppProps) {
 				<Component {...pageProps}></Component>
 			</Hydrate>
 		</QueryClientProvider>
+		
 	)
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2258,11 +2258,6 @@
   "resolved" "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz"
   "version" "4.2.9"
 
-"hamt_plus@1.0.2":
-  "integrity" "sha1-4hwlKWjH4zsg9qGwlM2FeHomVgE="
-  "resolved" "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz"
-  "version" "1.0.2"
-
 "har-schema@^2.0.0":
   "integrity" "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
   "resolved" "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz"
@@ -4332,7 +4327,7 @@
     "broadcast-channel" "^3.4.1"
     "match-sorter" "^6.0.2"
 
-"react@^16.8.0 || ^17.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^17.0.2 || ^18.0.0-0", "react@>= 16.8.0 || 17.x.x || ^18.0.0-0", "react@>=16", "react@>=16.13.1", "react@>=16.8.0", "react@17.0.2":
+"react@^16.8.0 || ^17.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^17.0.2 || ^18.0.0-0", "react@>= 16.8.0 || 17.x.x || ^18.0.0-0", "react@>=16", "react@>=16.8.0", "react@17.0.2":
   "integrity" "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA=="
   "resolved" "https://registry.npmjs.org/react/-/react-17.0.2.tgz"
   "version" "17.0.2"
@@ -4387,13 +4382,6 @@
   "version" "3.6.0"
   dependencies:
     "picomatch" "^2.2.1"
-
-"recoil@^0.7.2":
-  "integrity" "sha512-OT4pI7FOUHcIoRtjsL5Lqq+lFFzQfir4MIbUkqyJ3nqv3WfBP1pHepyurqTsK5gw+T+I2R8+uOD28yH+Lg5o4g=="
-  "resolved" "https://registry.npmjs.org/recoil/-/recoil-0.7.2.tgz"
-  "version" "0.7.2"
-  dependencies:
-    "hamt_plus" "1.0.2"
 
 "redent@^3.0.0":
   "integrity" "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="

--- a/yarn.lock
+++ b/yarn.lock
@@ -294,9 +294,9 @@
   dependencies:
     "glob" "7.1.7"
 
-"@next/swc-win32-x64-msvc@12.1.1":
-  "integrity" "sha512-nH5osn/uK9wsjT8Jh1YxMtRrkN5hoCNLQjsEdvfUfb+loQXeYiBd3n/0DUJkf6Scjfv6/htfUTPP3AEa7AbBxQ=="
-  "resolved" "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.1.tgz"
+"@next/swc-darwin-arm64@12.1.1":
+  "integrity" "sha512-bKKSNaTdnO3XPnfaR4NSpPcbs80fdbtOYC2lgtqLzA0bOMioupixMP5GrA/gfJHwh7GRH+A+sbgKQWsqSsYAqQ=="
+  "resolved" "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.1.tgz"
   "version" "12.1.1"
 
 "@nodelib/fs.scandir@2.1.5":
@@ -2087,6 +2087,11 @@
   "resolved" "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   "version" "1.0.0"
 
+"fsevents@~2.3.2":
+  "integrity" "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="
+  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
+  "version" "2.3.2"
+
 "function-bind@^1.1.1":
   "integrity" "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
   "resolved" "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"
@@ -2252,6 +2257,11 @@
   "integrity" "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
   "resolved" "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz"
   "version" "4.2.9"
+
+"hamt_plus@1.0.2":
+  "integrity" "sha1-4hwlKWjH4zsg9qGwlM2FeHomVgE="
+  "resolved" "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz"
+  "version" "1.0.2"
 
 "har-schema@^2.0.0":
   "integrity" "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
@@ -2912,6 +2922,11 @@
   dependencies:
     "array-includes" "^3.1.3"
     "object.assign" "^4.1.2"
+
+"jwt-decode@^3.1.2":
+  "integrity" "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+  "resolved" "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz"
+  "version" "3.1.2"
 
 "kind-of@^6.0.3":
   "integrity" "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
@@ -4317,7 +4332,7 @@
     "broadcast-channel" "^3.4.1"
     "match-sorter" "^6.0.2"
 
-"react@^16.8.0 || ^17.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^17.0.2 || ^18.0.0-0", "react@>= 16.8.0 || 17.x.x || ^18.0.0-0", "react@>=16", "react@>=16.8.0", "react@17.0.2":
+"react@^16.8.0 || ^17.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^17.0.2 || ^18.0.0-0", "react@>= 16.8.0 || 17.x.x || ^18.0.0-0", "react@>=16", "react@>=16.13.1", "react@>=16.8.0", "react@17.0.2":
   "integrity" "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA=="
   "resolved" "https://registry.npmjs.org/react/-/react-17.0.2.tgz"
   "version" "17.0.2"
@@ -4372,6 +4387,13 @@
   "version" "3.6.0"
   dependencies:
     "picomatch" "^2.2.1"
+
+"recoil@^0.7.2":
+  "integrity" "sha512-OT4pI7FOUHcIoRtjsL5Lqq+lFFzQfir4MIbUkqyJ3nqv3WfBP1pHepyurqTsK5gw+T+I2R8+uOD28yH+Lg5o4g=="
+  "resolved" "https://registry.npmjs.org/recoil/-/recoil-0.7.2.tgz"
+  "version" "0.7.2"
+  dependencies:
+    "hamt_plus" "1.0.2"
 
 "redent@^3.0.0":
   "integrity" "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="


### PR DESCRIPTION
## 티켓

[CAPS-86](https://2022springcapstone.atlassian.net/browse/CAPS-86?atlOrigin=eyJpIjoiYzhmZDdhZTM3YmNlNDljZmE0N2QzMDRhY2U1MTY5ODAiLCJwIjoiaiJ9)

## 작업 내용
- [x] `User.ts` `signIn` 함수 구현
- [x] `User.ts` `signOut` 함수 구현
- [x] `User.ts` `isLoggined` 함수 구현

## 전달사항 (코드 설명)
- `siginIn` -> 로그인 url로 요청을 보냄 
- `isLogined`-> 쿠키를 가져와서 refresh 쿠키가 존재하면 login으로 봄 -> refresh가 만료 되더라도 백엔드에서 검사해서 넘겨주기 때문에 프론트에서는 존재 여부만 확인함
- `signOut`에서는 refresh access 둘다 삭제 시킴
## 궁굼한거
- 현재는 `User.ts` Line 35에 Access, Refresh토큰을 둘 다 확인하는데 백엔드에서는  Access가 없어도 Refreshf를 다시 발급해주기 때문에 Refresh만 검사해도 될까요?
- 아래 경고가 나는데 [여기](https://www.inflearn.com/questions/16195)에서 보면  렌더링 시 html 구조가 살짝 달라서 발생하기 때문에 해결하기 어렵다고 합니다. 해결방법이 있을까요?
<img width="754" alt="image" src="https://user-images.githubusercontent.com/76805070/166187857-d3c1e0cd-9e4e-4f55-be9a-360dcd43581a.png">

