### PR TITLE
CAPS107/ Discussion 생성 CSS

### DIFF
--- a/components/DiscussionDetail/ReviewList.tsx
+++ b/components/DiscussionDetail/ReviewList.tsx
@@ -10,15 +10,14 @@ type Props = {
 }
 const ReviewList: React.FC<Props> = ({ discussion }) => {
 	// get reviews using page query
-	const [page, setPage] = useState<number>(2)
-	const { isLoading, isError, error, data, isFetching, isPreviousData } =
-		useQuery(
-			['reviews', page, discussion.id],
-			() => getReviewByDiscussionId(discussion.id, page),
-			{
-				keepPreviousData: false
-			}
-		)
+	const [page, setPage] = useState<number>(1)
+	const { isLoading, isError, data } = useQuery(
+		['reviews', page, discussion.id],
+		() => getReviewByDiscussionId(discussion.id, page),
+		{
+			keepPreviousData: false
+		}
+	)
 	const [availablePages, setAvailablePages] = useState<number[]>([])
 
 	useEffect(() => {
@@ -39,7 +38,6 @@ const ReviewList: React.FC<Props> = ({ discussion }) => {
 	if (isLoading) return <Spinner />
 	if (isError) return <div>Error</div>
 
-	// infinite scroll
 	return (
 		<div className="flex flex-col">
 			<div className="border-t-2 my-10">

--- a/components/LiveReviewReservation/LiveReviewCalendar.tsx
+++ b/components/LiveReviewReservation/LiveReviewCalendar.tsx
@@ -35,7 +35,7 @@ const LiveReviewCalendar: React.FunctionComponent<Props> = ({
 					liveReviewRequired ? '' : 'btn-disabled'
 				}`}
 			>
-				Live Review Picker
+				시간대 선택
 			</a>
 			<div className="modal" id="liveReviewModal">
 				<div className="modal-box">

--- a/components/createDiscussion/AddDiscussionCode.tsx
+++ b/components/createDiscussion/AddDiscussionCode.tsx
@@ -1,0 +1,77 @@
+import { DirectCode } from '../../api/Discussion'
+import DirectCodeComponent from './DirectCodeComponent'
+import PRorCommit from './PRorCommit'
+
+type Props = {
+	discussionType: 'DIRECT' | 'COMMIT' | 'PR'
+	setDiscussionType: any
+	codes: DirectCode[]
+	setCodes: any
+	selectedRepo: number
+	setSelectedRepo: any
+	selectedGitNode: string
+	setSelectedGitNode: any
+}
+
+const AddDiscussionCode: React.FC<Props> = ({
+	discussionType,
+	codes,
+	setCodes,
+	setDiscussionType,
+	selectedRepo,
+	setSelectedRepo,
+	selectedGitNode,
+	setSelectedGitNode
+}) => {
+	const selectDirect = () => {
+		setDiscussionType('DIRECT')
+	}
+	const selectPRorCommit = () => {
+		setDiscussionType('PR')
+	}
+
+	return (
+		<div className="w-full">
+			<div className="text-xl mb-6 ml-4">
+				리뷰받을 코드를 어디에서 가져올까요?
+			</div>
+			<div className="flex w-full">
+				<div className="flex flex-col">
+					<div
+						className={`btn w-[15rem] h-[10rem] ${
+							discussionType == 'DIRECT' ? 'btn-accent' : 'btn-ghost'
+						}`}
+						onClick={selectDirect}
+					>
+						직접 작성하기
+					</div>
+					<div
+						className={`btn w-[15rem] h-[10rem] ${
+							discussionType != 'DIRECT' ? 'btn-accent' : 'btn-ghost'
+						}`}
+						onClick={selectPRorCommit}
+					>
+						GitHub에서 가져오기
+					</div>
+				</div>
+				<div className="m-2 w-full">
+					{discussionType === 'DIRECT' && (
+						<DirectCodeComponent codes={codes} setCodes={setCodes} />
+					)}
+					{(discussionType === 'PR' || discussionType === 'COMMIT') && (
+						<PRorCommit
+							discussionType={discussionType}
+							setDiscussionType={setDiscussionType}
+							selectedRepo={selectedRepo}
+							setSelectedRepo={setSelectedRepo}
+							selectedGitNode={selectedGitNode}
+							setSelectedGitNode={setSelectedGitNode}
+						/>
+					)}
+				</div>
+			</div>
+		</div>
+	)
+}
+
+export default AddDiscussionCode

--- a/components/createDiscussion/AddTitleAndQuestion.tsx
+++ b/components/createDiscussion/AddTitleAndQuestion.tsx
@@ -1,0 +1,33 @@
+import QuestionContent from './QuestionContent'
+
+const AddTitleAndQuestion = ({
+	title,
+	setTitle,
+	question,
+	setQuestion
+}: {
+	title: any
+	setTitle: any
+	question: any
+	setQuestion: any
+}) => {
+	return (
+		<div className="w-full">
+			<div className="title-container">
+				<div className="text-xl mb-2 ml-4">제목을 입력하세요</div>
+				<input
+					type="text"
+					placeholder="어떤 문제를 겪고 있는지 간결하게 소개해주세요"
+					className="input input-bordered w-full m-2"
+					value={title}
+					onChange={(e) => setTitle(e.target.value)}
+				/>
+			</div>
+			<div className="question-container m-2 h-[30rem]">
+				<QuestionContent question={question} setQuestion={setQuestion} />
+			</div>
+		</div>
+	)
+}
+
+export default AddTitleAndQuestion

--- a/components/createDiscussion/DirectCodeComponent.tsx
+++ b/components/createDiscussion/DirectCodeComponent.tsx
@@ -72,50 +72,52 @@ const DirectCodeComponent: React.FunctionComponent<Props> = ({
 					Add Code
 				</div>
 			</div>
-			{codes.map((code, idx) => {
-				return (
-					<div key={idx} className="flex flex-col">
-						<div className="flex flex-row items-center">
-							<input
-								type="text"
-								placeholder="File명을 입력하세요"
-								className="input input-bordered w-full max-w-[10rem] mt-2 mb-2"
-								value={code.filename}
-								onChange={(e) => handleChangeName(e.target.value, idx)}
-							/>
-							<select
-								className="select select-bordered ml-2"
-								value={code.language}
-								onChange={(e) => handleLanguage(e.target.value, idx)}
-							>
-								{languageGroup.map((lang) => {
-									return (
-										<option key={lang} value={lang}>
-											{lang}
-										</option>
-									)
-								})}
-							</select>
-							<div
-								className="btn btn-error ml-2"
-								onClick={() => handleDeleteFile(idx)}
-							>
-								X
-							</div>
-						</div>
-						<div>
-							<div className="border-solid border-2 min-w-[20rem] w-[40rem]">
-								<MonacoEditor
-									code={code}
-									handleChangeCode={handleChangeCode}
-									idx={idx}
-									language={code.language}
+			<div>
+				{codes.map((code, idx) => {
+					return (
+						<div key={idx} className="flex flex-col">
+							<div className="flex flex-row items-center">
+								<input
+									type="text"
+									placeholder="File명을 입력하세요"
+									className="input input-bordered w-full max-w-[10rem] mt-2 mb-2"
+									value={code.filename}
+									onChange={(e) => handleChangeName(e.target.value, idx)}
 								/>
+								<select
+									className="select select-bordered ml-2"
+									value={code.language}
+									onChange={(e) => handleLanguage(e.target.value, idx)}
+								>
+									{languageGroup.map((lang) => {
+										return (
+											<option key={lang} value={lang}>
+												{lang}
+											</option>
+										)
+									})}
+								</select>
+								<div
+									className="btn btn-error ml-2"
+									onClick={() => handleDeleteFile(idx)}
+								>
+									X
+								</div>
+							</div>
+							<div>
+								<div className="border-solid border-2">
+									<MonacoEditor
+										code={code}
+										handleChangeCode={handleChangeCode}
+										idx={idx}
+										language={code.language}
+									/>
+								</div>
 							</div>
 						</div>
-					</div>
-				)
-			})}
+					)
+				})}
+			</div>
 		</div>
 	)
 }

--- a/components/createDiscussion/MonacoEditor.tsx
+++ b/components/createDiscussion/MonacoEditor.tsx
@@ -21,7 +21,7 @@ export const MonacoEditor: React.FunctionComponent<Props> = ({
 }) => {
 	return (
 		<Editor
-			height="15rem"
+			height="20rem"
 			defaultLanguage="javascript"
 			language={language}
 			value={code.content}

--- a/components/createDiscussion/PRorCommit.tsx
+++ b/components/createDiscussion/PRorCommit.tsx
@@ -1,83 +1,126 @@
 import { useState } from 'react'
 import { useQuery } from 'react-query'
 import { getCommits, getMyRepos, getPullRequests } from '../../api/Github'
+import Spinner from '../Common/Spinner'
 
 type Props = {
 	discussionType: 'DIRECT' | 'COMMIT' | 'PR'
 	setDiscussionType: (value: 'DIRECT' | 'COMMIT' | 'PR') => void
+	selectedRepo: number
+	setSelectedRepo: any
+	selectedGitNode: string
+	setSelectedGitNode: any
 }
 
 const PRorCommit: React.FunctionComponent<Props> = ({
 	discussionType,
-	setDiscussionType
+	setDiscussionType,
+	selectedRepo,
+	setSelectedRepo,
+	selectedGitNode,
+	setSelectedGitNode
 }) => {
-	const [selectedRepo, setSelectedRepo] = useState<number>(-1)
-	const query = useQuery('getMyRepo', getMyRepos)
-	const commitsQuery = useQuery('repoCommits', () => getCommits(selectedRepo), {
-		enabled: selectedRepo > 0
-	})
-	const prQuery = useQuery(
-		'repoPullRequests',
-		() => getPullRequests(selectedRepo),
+	const { isLoading: isRepoLoading, data: repos } = useQuery(
+		'getMyRepo',
+		getMyRepos
+	)
+	const { isLoading: isCommitsLoading, data: commits } = useQuery(
+		`repoCommits${selectedRepo}`,
+		() => getCommits(selectedRepo),
 		{
-			enabled: selectedRepo > 0
+			enabled: selectedRepo > 0 && discussionType === 'COMMIT'
 		}
 	)
+	const { isLoading: isPrLoading, data: prs } = useQuery(
+		`repoPullRequests${selectedRepo}`,
+		() => getPullRequests(selectedRepo),
+		{
+			enabled: selectedRepo > 0 && discussionType === 'PR'
+		}
+	)
+
 	return (
 		<div className="flex flex-col">
-			<select
-				className="select select-primary w-full max-w-xs mb-2"
-				onChange={(e) => setSelectedRepo(parseInt(e.target.value))}
-			>
-				<option disabled selected>
-					Get my Repository
-				</option>
-				{query.data?.map((repository, idx) => (
-					<option key={idx} value={repository.id}>
-						{repository.fullName}
-					</option>
-				))}
-			</select>
-			{selectedRepo > -1 && (
-				<div>
-					<div
-						className="btn btn-ghost border-2 border-solid"
-						onClick={() => setDiscussionType('COMMIT')}
+			{isRepoLoading ? (
+				<Spinner />
+			) : (
+				<div className="flex">
+					<select
+						className="select select-primary w-full max-w-xs mb-6 mr-6"
+						onChange={(e) => setSelectedRepo(parseInt(e.target.value))}
 					>
-						Get my Commits
-					</div>
-					<div
-						className="btn btn-ghost border-2 border-solid"
-						onClick={() => setDiscussionType('PR')}
-					>
-						Get my pull Requests
-					</div>
+						<option disabled selected>
+							Repository 선택하기
+						</option>
+						{repos?.map((repository, idx) => (
+							<option key={idx} value={repository.id}>
+								{repository.fullName}
+							</option>
+						))}
+					</select>
+					{selectedRepo > -1 && (
+						<div className="">
+							<div
+								className={`btn border-2 border-solid mr-6 ${
+									discussionType === 'COMMIT' && 'btn-primary'
+								}`}
+								onClick={() => setDiscussionType('COMMIT')}
+							>
+								Commit 가져오기
+							</div>
+							<div
+								className={`btn border-2 border-solid ${
+									discussionType === 'PR' && 'btn-primary'
+								}`}
+								onClick={() => setDiscussionType('PR')}
+							>
+								Pull Request 가져오기
+							</div>
+						</div>
+					)}
 				</div>
 			)}
-			{discussionType === 'COMMIT' && (
-				<select className="select select-primary w-full max-w-xs">
-					<option disabled selected>
-						Get my Commits
-					</option>
-					{commitsQuery.data?.map((commit, idx) => (
-						<option key={idx} value={commit.sha}>
-							{commit.message}
-						</option>
+			<div className="flex flex-col border-2 overflow-y-scroll h-[30rem]">
+				{(isCommitsLoading || isPrLoading) && <Spinner />}
+				{discussionType === 'COMMIT' &&
+					commits?.map((commit, idx) => (
+						<div key={idx} className="flex p-4 text-lg items-center">
+							<input
+								type="radio"
+								className="radio radio-primary"
+								checked={selectedGitNode === commit.sha}
+								onChange={() => setSelectedGitNode(commit.sha)}
+							/>
+							<a
+								href={commit.url}
+								target="_blank"
+								className="ml-4"
+								rel="noreferrer"
+							>
+								{commit.message}
+							</a>
+						</div>
 					))}
-				</select>
-			)}
-			{discussionType === 'PR' && (
-				<select className="select select-primary w-full max-w-xs">
-					<option disabled selected>
-						Get my Pull Requests
-					</option>
-					{prQuery.data?.map((pr, idx) => (
-						<option key={idx} value={pr.id}>
-							{pr.title}
-						</option>
+				{discussionType === 'PR' &&
+					prs?.map((pr, idx) => (
+						<div key={idx} className="flex p-4 text-lg items-center">
+							<input
+								type="radio"
+								className="radio radio-primary"
+								checked={selectedGitNode === pr.id}
+								onChange={() => setSelectedGitNode(pr.id)}
+							/>
+							<a
+								href={pr.url}
+								target="_blank"
+								className="ml-4"
+								rel="noreferrer"
+							>
+								{pr.title}
+							</a>
+						</div>
 					))}
-				</select>
-			)}
+			</div>
 		</div>
 	)
 }

--- a/components/createDiscussion/QuestionContent.tsx
+++ b/components/createDiscussion/QuestionContent.tsx
@@ -15,10 +15,11 @@ const QuestionContent: React.FunctionComponent<Props> = ({
 		setQuestion(value!)
 	}
 	return (
-		<div>
+		<div className="h-full">
 			<div className="text-xl mb-2 ml-2">질문 내용을 작성하세요</div>
 			<MarkdownEditor
-				className="input input-bordered w-full max-w-[40rem] m-2"
+				height={450}
+				className="input input-bordered w-full m-2 h-full"
 				value={question}
 				onChange={(value) => handleChangeQuestion(value)}
 			/>

--- a/components/createDiscussion/ReceiveLiveReview.tsx
+++ b/components/createDiscussion/ReceiveLiveReview.tsx
@@ -1,0 +1,41 @@
+import LiveReviewCalendar from '../LiveReviewReservation/LiveReviewCalendar'
+
+const ReceiveLiveReview = ({
+	liveReviewRequired,
+	setLiveReviewRequired,
+	liveReviewAvailableTimes,
+	setLiveReviewAvailableTimes
+}: {
+	liveReviewRequired: any
+	setLiveReviewRequired: any
+	liveReviewAvailableTimes: any
+	setLiveReviewAvailableTimes: any
+}) => {
+	const clickLiveReviewCheck = () => {
+		setLiveReviewRequired(!liveReviewRequired)
+	}
+
+	return (
+		<div className="flex flex-col items-center m-2">
+			<div className="text-xl mb-2 ml-4">
+				리뷰어와 더 원활하게 소통할 수 있는 Live Review는 어떠신가요?
+			</div>
+			<div className="flex items-center">
+				<input
+					type="checkbox"
+					className="checkbox mr-2"
+					onClick={clickLiveReviewCheck}
+					checked={liveReviewRequired}
+				/>
+				<p className="mr-2">Live Review</p>
+				<LiveReviewCalendar
+					liveReviewRequired={liveReviewRequired}
+					liveReviewAvailableTimes={liveReviewAvailableTimes}
+					setLiveReviewAvailableTimes={setLiveReviewAvailableTimes}
+				/>
+			</div>
+		</div>
+	)
+}
+
+export default ReceiveLiveReview

--- a/components/createDiscussion/SelectTagComponent.tsx
+++ b/components/createDiscussion/SelectTagComponent.tsx
@@ -22,16 +22,21 @@ const SelectTagComponent: React.FunctionComponent<Props> = ({
 	}
 	return (
 		<div>
-			{tags?.map((tag, index) => (
-				<div key={index} className="inline">
-					<TagButton
-						index={tag.id}
-						tagName={tag.name}
-						selectedTagIds={selectedTagIds}
-						setSelectedTagIds={setSelectedTagIds}
-					/>
-				</div>
-			))}
+			<div className="text-xl mb-2 ml-4">
+				Discussion을 표현할 수 있는 태그를 선택해주세요
+			</div>
+			<div>
+				{tags?.map((tag, index) => (
+					<div key={index} className="inline">
+						<TagButton
+							index={tag.id}
+							tagName={tag.name}
+							selectedTagIds={selectedTagIds}
+							setSelectedTagIds={setSelectedTagIds}
+						/>
+					</div>
+				))}
+			</div>
 		</div>
 	)
 }

--- a/hooks/useUserId.ts
+++ b/hooks/useUserId.ts
@@ -3,6 +3,7 @@ import { isLogin } from '../api/User'
 
 export const useUserId = () => {
 	const [userId, setUserId] = useState<number | null>(null)
+	const [init, setInit] = useState<boolean>(false)
 
 	useEffect(() => {
 		if (!window) {
@@ -12,10 +13,12 @@ export const useUserId = () => {
 		if (userId > 0) {
 			setUserId(userId)
 		}
+		setInit(true)
 	}, [])
 
 	return {
 		userId,
-		isLoggedIn: userId !== null
+		isLoggedIn: userId !== null,
+		init
 	}
 }

--- a/pages/create/discussion.tsx
+++ b/pages/create/discussion.tsx
@@ -2,12 +2,28 @@ import type { NextPage } from 'next'
 import Head from 'next/head'
 import Layout from '../../components/layout/layout'
 import CreateDiscussionComponent from '../../components/createDiscussion/CreateDiscussionComponent'
+import { useUserId } from '../../hooks/useUserId'
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
 
-const createDiscussion: NextPage = () => {
+const CreateDiscussion: NextPage = () => {
+	const router = useRouter()
+	const { init, isLoggedIn } = useUserId()
+
+	useEffect(() => {
+		if (!init) {
+			return
+		}
+		if (!isLoggedIn) {
+			alert('로그인 후 이용해주세요.')
+			router.push('/')
+		}
+	}, [init, isLoggedIn, router])
+
 	return (
 		<div>
 			<Head>
-				<title>Create Next App</title>
+				<title>Discussion 추가</title>
 			</Head>
 			<Layout>
 				<div className="m-3 min-h-[36rem]">
@@ -18,4 +34,4 @@ const createDiscussion: NextPage = () => {
 	)
 }
 
-export default createDiscussion
+export default CreateDiscussion


### PR DESCRIPTION
## 티켓

[CAPS-107]()

## 작업 내용
- Discussion 생성 API 연결 수정 => GitHub 연동 추가
- 생성 progress에 따른 컴포넌트 분리 => progress 진행에 따라 유효성 검사
- 기타) `ReviewList` 처음 페이지 기존 버그 때문에 2로 해뒀던거 수정

## 전달사항
- 지금은 구현에 초점을 둬서 너무 더러운데 나중에 시간나면 `Props` 정리 한번 하면 좋을듯 ~
