### PR TITLE
CAPS-249: Discussion 생성 페이지 진입 및 생성 직후 렌더링 버그 수정

### DIFF
--- a/components/createDiscussion/CreateDiscussionComponent.tsx
+++ b/components/createDiscussion/CreateDiscussionComponent.tsx
@@ -149,7 +149,7 @@ const CreateDiscussionComponent: React.FunctionComponent<Props> = () => {
 				gitNodeId: discussionType !== 'DIRECT' ? selectedGitNode : undefined
 			})
 			alert('생성이 완료되었습니다.')
-			router.push(`/discussion/${discussion.id}`)
+			window.location.href = `/discussion/${discussion.id}`
 		} catch (e) {
 			console.error(e)
 			alert("can't create discussion.")

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -8,7 +8,9 @@ interface HeaderProps {}
 
 const Header: FunctionComponent<HeaderProps> = () => {
 	const { isLoggedIn } = useUserId()
-
+	const onLinkClick = () => {
+		window.location.href = '/create/discussion'
+	}
 	return (
 		<div className="navbar bg-base-100 border-b-2 min-w-[65rem]">
 			<div className="flex-1">
@@ -20,11 +22,12 @@ const Header: FunctionComponent<HeaderProps> = () => {
 				{isLoggedIn && <ReviewAvailable />}
 				{isLoggedIn ? (
 					<div className="flex flex-row justify-center">
-						<Link href="/create/discussion" passHref>
-							<button className="btn bg-primary mr-2 normal-case">
-								Create a Discussion
-							</button>
-						</Link>
+						<button
+							className="btn bg-primary mr-2 normal-case"
+							onClick={onLinkClick}
+						>
+							Create a Discussion
+						</button>
 						<div className="dropdown dropdown-end">
 							<button className="btn btn-ghost btn-circle">
 								<div className="indicator">


### PR DESCRIPTION
## 티켓

[CAPS-249](https://2022springcapstone.atlassian.net/browse/CAPS-249)

## 작업 내용
- 헤더의 'create a discussion'버튼으로 생성 페이지 이동 시 렌더링 문제 해결
- 생성 직후 해당 discussion 페이지로 이동 시 렌더링 문제 해결
