### PR TITLE
CAPS-240: 목록페이지 pagination 수정

### DIFF
--- a/api/Discussion.ts
+++ b/api/Discussion.ts
@@ -108,7 +108,7 @@ export async function getDiscussionById(
 
 export async function getDiscussions(data: {
 	page?: string | string[]
-	tags?: string | string[]
+	tags?: number | number[]
 	state?: string | string[]
 	keyword?: string | string[]
 	sort?: string | string[]

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -15,7 +15,7 @@ const Sidebar: FunctionComponent<SidebarProps> = () => (
 				</Link>
 			</li>
 			<li className="relative">
-				<Link href="/list?page=1">
+				<Link href={`/list?page=1&state=&tags=&keyword=&onlyMine=`}>
 					<a className="flex items-center text-sm py-4 px-6 h-12 overflow-hidden text-gray-700 text-ellipsis whitespace-nowrap rounded hover:text-gray-900 hover:bg-gray-300 transition duration-300 ease-in-out">
 						Discussions
 					</a>

--- a/components/listComponents/FilterTagButton.tsx
+++ b/components/listComponents/FilterTagButton.tsx
@@ -14,7 +14,9 @@ const FilterTagButton: React.FunctionComponent<Props> = ({
 	selectedFilters,
 	setSelectedFilters
 }) => {
-	const [select, setSelect] = useState<boolean>(false)
+	const [select, setSelect] = useState<boolean>(
+		selectedFilters.includes(tag.id)
+	)
 	const clickTag = () => {
 		if (!select) {
 			setSelectedFilters([...selectedFilters, tag.id])

--- a/components/listComponents/ListComponent.tsx
+++ b/components/listComponents/ListComponent.tsx
@@ -1,30 +1,31 @@
+import { useRouter } from 'next/router'
 import { useState } from 'react'
-import { useQuery } from 'react-query'
-import { DiscussionFilter, getDiscussions } from '../../api/Discussion'
+import { DiscussionFilter, DiscussionListResponse } from '../../api/Discussion'
 import DiscussionList from './DiscussionList'
 import ListFilter from './ListFilter'
 import Pagination from './Pagination'
-import { useRouter } from 'next/router'
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-type Props = {}
+type Props = {
+	discussions: DiscussionListResponse
+}
 
-const ListComponent: React.FunctionComponent<Props> = () => {
+const ListComponent: React.FunctionComponent<Props> = ({ discussions }) => {
 	const router = useRouter()
-	const { page, tags, state, keyword, sort, onlyMine } = router.query
+	const tags = router.query.tags
+		? (router.query.tags as string).split(',').map((tag) => Number(tag))
+		: []
+	const state = router.query.state as
+		| 'NOT_REVIEWED'
+		| 'REVIEWING'
+		| 'COMPLETED'
+		| undefined
+	const keyword = router.query.keyword as string
 	const [discussionFilter, setDiscussionFilter] = useState<DiscussionFilter>({
 		onlyMine: false,
-		tags: [],
-		keyword: '',
-		state: 'NOT_REVIEWED'
+		tags: tags,
+		keyword: keyword,
+		state: state
 	})
-	const {
-		data: discussions,
-		isLoading,
-		error
-	} = useQuery('discussions', () =>
-		getDiscussions({ page, tags, state, keyword, sort, onlyMine })
-	)
 	return (
 		<>
 			<ListFilter

--- a/components/listComponents/ListComponent.tsx
+++ b/components/listComponents/ListComponent.tsx
@@ -1,16 +1,17 @@
 import { useRouter } from 'next/router'
 import { useState } from 'react'
-import { DiscussionFilter, DiscussionListResponse } from '../../api/Discussion'
+import { useQuery } from 'react-query'
+import { DiscussionFilter, getDiscussions } from '../../api/Discussion'
 import DiscussionList from './DiscussionList'
 import ListFilter from './ListFilter'
 import Pagination from './Pagination'
 
-type Props = {
-	discussions: DiscussionListResponse
-}
+// eslint-disable-next-line @typescript-eslint/ban-types
+type Props = {}
 
-const ListComponent: React.FunctionComponent<Props> = ({ discussions }) => {
+const ListComponent: React.FunctionComponent<Props> = () => {
 	const router = useRouter()
+	const { page, sort, onlyMine } = router.query
 	const tags = router.query.tags
 		? (router.query.tags as string).split(',').map((tag) => Number(tag))
 		: []
@@ -26,6 +27,14 @@ const ListComponent: React.FunctionComponent<Props> = ({ discussions }) => {
 		keyword: keyword,
 		state: state
 	})
+	const {
+		data: discussions,
+		isLoading,
+		error
+	} = useQuery(
+		`discussions?page=${page}&state=${state}&tags=${tags}&keyword=${keyword}&onlyMine=false`,
+		() => getDiscussions({ page, tags, state, keyword, sort, onlyMine })
+	)
 	return (
 		<>
 			<ListFilter

--- a/components/listComponents/ListComponent.tsx
+++ b/components/listComponents/ListComponent.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useQuery } from 'react-query'
 import { DiscussionFilter, getDiscussions } from '../../api/Discussion'
 import DiscussionList from './DiscussionList'
@@ -11,21 +11,15 @@ type Props = {}
 
 const ListComponent: React.FunctionComponent<Props> = () => {
 	const router = useRouter()
-	const { page, sort, onlyMine } = router.query
+	const { page, state, keyword, sort, onlyMine } = router.query
 	const tags = router.query.tags
 		? (router.query.tags as string).split(',').map((tag) => Number(tag))
 		: []
-	const state = router.query.state as
-		| 'NOT_REVIEWED'
-		| 'REVIEWING'
-		| 'COMPLETED'
-		| undefined
-	const keyword = router.query.keyword as string
 	const [discussionFilter, setDiscussionFilter] = useState<DiscussionFilter>({
 		onlyMine: false,
-		tags: tags,
-		keyword: keyword,
-		state: state
+		tags: [],
+		keyword: '',
+		state: undefined
 	})
 	const {
 		data: discussions,
@@ -35,6 +29,20 @@ const ListComponent: React.FunctionComponent<Props> = () => {
 		`discussions?page=${page}&state=${state}&tags=${tags}&keyword=${keyword}&onlyMine=false`,
 		() => getDiscussions({ page, tags, state, keyword, sort, onlyMine })
 	)
+	useEffect(() => {
+		setDiscussionFilter({
+			onlyMine: false,
+			tags: router.query.tags
+				? (router.query.tags as string).split(',').map((tag) => Number(tag))
+				: [],
+			keyword: router.query.keyword as string,
+			state: router.query.state as
+				| 'NOT_REVIEWED'
+				| 'REVIEWING'
+				| 'COMPLETED'
+				| undefined
+		})
+	}, [router])
 	return (
 		<>
 			<ListFilter

--- a/components/listComponents/ListFilter.tsx
+++ b/components/listComponents/ListFilter.tsx
@@ -69,7 +69,11 @@ const ListFilter: React.FunctionComponent<FilterProps> = ({
 					/>
 				</div>
 				<Link
-					href={`/list?page=1&state=${discussionFilter.state}&tags=${discussionFilter.tags}&keyword=${discussionFilter.keyword}&onlyMine=false`}
+					href={`/list?page=1
+					&state=${discussionFilter.state ?? ''}
+					&tags=${discussionFilter.tags ?? ''}
+					&keyword=${discussionFilter.keyword ?? ''}
+					&onlyMine=false`}
 					passHref
 				>
 					<button className="btn btn-accent">설정 완료</button>

--- a/components/listComponents/Pagination.tsx
+++ b/components/listComponents/Pagination.tsx
@@ -9,9 +9,10 @@ const Pagination: React.FunctionComponent<Props> = ({ discussionAmount }) => {
 	const router = useRouter()
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 	const maxPageNumber = Math.ceil(discussionAmount! / 5)
-	const { page, tags, state, keyword, sort, onlyMine } = router.query
-	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	const currentPage = parseInt(page! as string)
+	const { tags, state, keyword, sort, onlyMine } = router.query
+	const currentPage = router.query.page
+		? parseInt(router.query.page as string)
+		: 1
 	const pageArray = [
 		currentPage - 2,
 		currentPage - 1,
@@ -25,7 +26,11 @@ const Pagination: React.FunctionComponent<Props> = ({ discussionAmount }) => {
 				{pageArray.map((pageNumber) => (
 					<Link
 						key={pageNumber}
-						href={`/list?page=${pageNumber}&state=${state}&tags=${tags}&keyword=${keyword}&onlyMine=false`}
+						href={`/list?page=${pageNumber}
+							&state=${state ?? ''}
+							&tags=${tags ?? ''}
+							&keyword=${keyword ?? ''}
+							&onlyMine=false`}
 						passHref
 					>
 						<div

--- a/components/listComponents/Pagination.tsx
+++ b/components/listComponents/Pagination.tsx
@@ -9,7 +9,7 @@ const Pagination: React.FunctionComponent<Props> = ({ discussionAmount }) => {
 	const router = useRouter()
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 	const maxPageNumber = Math.ceil(discussionAmount! / 5)
-	const { page } = router.query
+	const { page, tags, state, keyword, sort, onlyMine } = router.query
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 	const currentPage = parseInt(page! as string)
 	const pageArray = [
@@ -19,19 +19,22 @@ const Pagination: React.FunctionComponent<Props> = ({ discussionAmount }) => {
 		currentPage + 1,
 		currentPage + 2
 	]
+	const onLinkClick = (pageNumber: number) => {
+		window.location.href = `/list?page=${pageNumber}&state=${state}&tags=${tags}&keyword=${keyword}&onlyMine=false`
+	}
 	return (
 		<div className="flex justify-center">
 			<div>
-				{pageArray.map((page) => (
-					<Link key={page} href={`/list?page=${page}`} passHref>
-						<div
-							className={`btn btn-sm m-1 ${
-								page < 1 || page > maxPageNumber ? `invisible` : ``
-							} ${page == currentPage ? `btn-active` : `btn-outline`}`}
-						>
-							{page}
-						</div>
-					</Link>
+				{pageArray.map((pageNumber) => (
+					<div
+						key={pageNumber}
+						onClick={() => onLinkClick(pageNumber)}
+						className={`btn btn-sm m-1 ${
+							pageNumber < 1 || pageNumber > maxPageNumber ? `invisible` : ``
+						} ${pageNumber == currentPage ? `btn-active` : `btn-outline`}`}
+					>
+						{pageNumber}
+					</div>
 				))}
 			</div>
 		</div>

--- a/components/listComponents/Pagination.tsx
+++ b/components/listComponents/Pagination.tsx
@@ -19,22 +19,23 @@ const Pagination: React.FunctionComponent<Props> = ({ discussionAmount }) => {
 		currentPage + 1,
 		currentPage + 2
 	]
-	const onLinkClick = (pageNumber: number) => {
-		window.location.href = `/list?page=${pageNumber}&state=${state}&tags=${tags}&keyword=${keyword}&onlyMine=false`
-	}
 	return (
 		<div className="flex justify-center">
 			<div>
 				{pageArray.map((pageNumber) => (
-					<div
+					<Link
 						key={pageNumber}
-						onClick={() => onLinkClick(pageNumber)}
-						className={`btn btn-sm m-1 ${
-							pageNumber < 1 || pageNumber > maxPageNumber ? `invisible` : ``
-						} ${pageNumber == currentPage ? `btn-active` : `btn-outline`}`}
+						href={`/list?page=${pageNumber}&state=${state}&tags=${tags}&keyword=${keyword}&onlyMine=false`}
+						passHref
 					>
-						{pageNumber}
-					</div>
+						<div
+							className={`btn btn-sm m-1 ${
+								pageNumber < 1 || pageNumber > maxPageNumber ? `invisible` : ``
+							} ${pageNumber == currentPage ? `btn-active` : `btn-outline`}`}
+						>
+							{pageNumber}
+						</div>
+					</Link>
 				))}
 			</div>
 		</div>

--- a/components/listComponents/SelectStateComponent.tsx
+++ b/components/listComponents/SelectStateComponent.tsx
@@ -8,6 +8,7 @@ const SelectStateComponent: React.FunctionComponent<Props> = ({
 	setSelectedState
 }) => {
 	const stateTags = [
+		{ id: '', name: 'All State' },
 		{ id: 'NOT_REVIEWED', name: 'Not reviewed' },
 		{ id: 'REVIEWING', name: 'Reviewing' },
 		{ id: 'COMPLETED', name: 'Completed' }
@@ -20,7 +21,7 @@ const SelectStateComponent: React.FunctionComponent<Props> = ({
 			{stateTags.map((state, index) => (
 				<div key={index} className="inline">
 					<div
-						className={`btn btn-small m-1 rounded-3xl h-[2.5rem] min-h-[2.5rem] ${
+						className={`btn btn-small normal-case m-1 rounded-3xl h-[2.5rem] min-h-[2.5rem] ${
 							selectedState == state.id ? `btn-success` : `btn-outline`
 						}`}
 						onClick={() => clickTag(state.id)}

--- a/pages/list.tsx
+++ b/pages/list.tsx
@@ -3,10 +3,7 @@ import Head from 'next/head'
 import Layout from '../components/layout/layout'
 import ListComponent from '../components/listComponents/ListComponent'
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-type Props = {}
-
-const listPage: NextPage<Props> = () => {
+const listPage: NextPage = () => {
 	return (
 		<div>
 			<Head>

--- a/pages/list.tsx
+++ b/pages/list.tsx
@@ -1,18 +1,12 @@
-import type {
-	GetServerSideProps,
-	GetServerSidePropsContext,
-	NextPage
-} from 'next'
+import type { NextPage } from 'next'
 import Head from 'next/head'
-import { DiscussionListResponse, getDiscussions } from '../api/Discussion'
 import Layout from '../components/layout/layout'
 import ListComponent from '../components/listComponents/ListComponent'
 
-type Props = {
-	discussions: DiscussionListResponse
-}
+// eslint-disable-next-line @typescript-eslint/ban-types
+type Props = {}
 
-const listPage: NextPage<Props> = ({ discussions }) => {
+const listPage: NextPage<Props> = () => {
 	return (
 		<div>
 			<Head>
@@ -20,31 +14,11 @@ const listPage: NextPage<Props> = ({ discussions }) => {
 			</Head>
 			<Layout>
 				<div className="m-3 min-h-[36rem]">
-					<ListComponent discussions={discussions} />
+					<ListComponent />
 				</div>
 			</Layout>
 		</div>
 	)
 }
-export const getServerSideProps: GetServerSideProps<Props> = async (
-	context: GetServerSidePropsContext
-) => {
-	const { page, tags, state, keyword, sort, onlyMine } = context.query
-	const discussions = await getDiscussions({
-		page,
-		tags,
-		state,
-		keyword,
-		sort,
-		onlyMine
-	})
-	if (!discussions) {
-		throw new Error('Discussion not found')
-	}
-	return {
-		props: {
-			discussions: discussions
-		}
-	}
-}
+
 export default listPage

--- a/pages/list.tsx
+++ b/pages/list.tsx
@@ -1,9 +1,18 @@
-import type { NextPage } from 'next'
+import type {
+	GetServerSideProps,
+	GetServerSidePropsContext,
+	NextPage
+} from 'next'
 import Head from 'next/head'
+import { DiscussionListResponse, getDiscussions } from '../api/Discussion'
 import Layout from '../components/layout/layout'
 import ListComponent from '../components/listComponents/ListComponent'
 
-const list: NextPage = () => {
+type Props = {
+	discussions: DiscussionListResponse
+}
+
+const listPage: NextPage<Props> = ({ discussions }) => {
 	return (
 		<div>
 			<Head>
@@ -11,11 +20,31 @@ const list: NextPage = () => {
 			</Head>
 			<Layout>
 				<div className="m-3 min-h-[36rem]">
-					<ListComponent />
+					<ListComponent discussions={discussions} />
 				</div>
 			</Layout>
 		</div>
 	)
 }
-
-export default list
+export const getServerSideProps: GetServerSideProps<Props> = async (
+	context: GetServerSidePropsContext
+) => {
+	const { page, tags, state, keyword, sort, onlyMine } = context.query
+	const discussions = await getDiscussions({
+		page,
+		tags,
+		state,
+		keyword,
+		sort,
+		onlyMine
+	})
+	if (!discussions) {
+		throw new Error('Discussion not found')
+	}
+	return {
+		props: {
+			discussions: discussions
+		}
+	}
+}
+export default listPage


### PR DESCRIPTION
## 티켓

[CAPS-240](https://2022springcapstone.atlassian.net/browse/CAPS-240)

## 작업 내용
- 목록 페이지 pagination 페이지 이동 시 렌더링 버그 픽스
- 목록 페이지 페이지를 넘어가거나 새로고침해도 필터 내용이 저장되도록 수정