### PR TITLE
Fix: PR 선택 불가 문제 및 style

### DIFF
--- a/components/createDiscussion/AddDiscussionCode.tsx
+++ b/components/createDiscussion/AddDiscussionCode.tsx
@@ -36,9 +36,9 @@ const AddDiscussionCode: React.FC<Props> = ({
 				리뷰받을 코드를 어디에서 가져올까요?
 			</div>
 			<div className="flex w-full">
-				<div className="flex flex-col">
+				<div className="flex flex-col mr-2">
 					<div
-						className={`btn w-[15rem] h-[10rem] ${
+						className={`btn w-[12rem] h-[4rem] mb-2 ${
 							discussionType == 'DIRECT' ? 'btn-accent' : 'btn-ghost'
 						}`}
 						onClick={selectDirect}
@@ -46,7 +46,7 @@ const AddDiscussionCode: React.FC<Props> = ({
 						직접 작성하기
 					</div>
 					<div
-						className={`btn w-[15rem] h-[10rem] ${
+						className={`btn w-[12rem] h-[4rem] ${
 							discussionType != 'DIRECT' ? 'btn-accent' : 'btn-ghost'
 						}`}
 						onClick={selectPRorCommit}
@@ -54,7 +54,7 @@ const AddDiscussionCode: React.FC<Props> = ({
 						GitHub에서 가져오기
 					</div>
 				</div>
-				<div className="m-2 w-full">
+				<div className="m-2 w-full min-h-[30rem]">
 					{discussionType === 'DIRECT' && (
 						<DirectCodeComponent codes={codes} setCodes={setCodes} />
 					)}

--- a/components/createDiscussion/PRorCommit.tsx
+++ b/components/createDiscussion/PRorCommit.tsx
@@ -48,8 +48,10 @@ const PRorCommit: React.FunctionComponent<Props> = ({
 					<select
 						className="select select-primary w-full max-w-xs mb-6 mr-6"
 						onChange={(e) => setSelectedRepo(parseInt(e.target.value))}
+						key={selectedRepo}
+						defaultValue={selectedRepo == -1 ? 'default' : selectedRepo}
 					>
-						<option disabled selected>
+						<option disabled selected value="default">
 							Repository 선택하기
 						</option>
 						{repos?.map((repository, idx) => (
@@ -101,6 +103,9 @@ const PRorCommit: React.FunctionComponent<Props> = ({
 							</a>
 						</div>
 					))}
+				{discussionType === 'COMMIT' && commits?.length == 0 && (
+					<span>Commit이 존재하지 않습니다.</span>
+				)}
 				{discussionType === 'PR' &&
 					prs?.map((pr, idx) => (
 						<div key={idx} className="flex p-4 text-lg items-center">
@@ -108,7 +113,7 @@ const PRorCommit: React.FunctionComponent<Props> = ({
 								type="radio"
 								className="radio radio-primary"
 								checked={selectedGitNode === pr.id.toString()}
-								onChange={() => setSelectedGitNode(pr.id)}
+								onChange={() => setSelectedGitNode(pr.id.toString())}
 							/>
 							<a
 								href={pr.url}
@@ -120,6 +125,9 @@ const PRorCommit: React.FunctionComponent<Props> = ({
 							</a>
 						</div>
 					))}
+				{discussionType === 'PR' && prs?.length == 0 && (
+					<span className="ml-4">Pull Request가 존재하지 않습니다.</span>
+				)}
 			</div>
 		</div>
 	)


### PR DESCRIPTION
## 작업 내용
- Discussion 생성 페이지에서 불러온 PR이 선택이 안되는 문제 수정
- Discussion 생성 페이지 style 일부 수정
- Commit 불러오기 / PR 불러오기에서 개수가 0일 때 처리
- Repository `select`에 `defaultValue` 추가